### PR TITLE
JUnit5 integrated in build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,15 @@ repositories {
     jcenter()
 }
 
+test {
+    // Uncomment a specific test engine below to use specifically otherwise
+    // By default all engines on the test runtime classpath will be used.
+    useJUnitPlatform {
+        // includeEngines 'junit-vintage'
+        // excludeEngines 'junit-jupiter'
+    }
+}
+
 dependencies {
     // This dependency is exported to consumers, that is to say found on their compile classpath.
     api 'org.apache.commons:commons-math3:3.6.1'
@@ -24,6 +33,9 @@ dependencies {
     // This dependency is used internally, and not exposed to consumers on their own compile classpath.
     implementation 'com.google.guava:guava:28.0-jre'
 
-    // Use JUnit test framework
-    testImplementation 'junit:junit:4.12'
-}
+    // JUnit 5 = JUnit Platform + JUnit Jupiter + JUnit Vintage
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.1.0'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.1.0'
+    // These dependancies are for backwards compatibility with JUnit3/4
+    testCompileOnly 'junit:junit:4.12'
+    testRuntimeOnly 'org.junit.vintage:junit-vintage-engine:5.1.0'}


### PR DESCRIPTION
This issue #106 addresses user story #104 to use JUnit5 instead of JUnit4 in the build.

As a part of JUnit5, included are packages to enable tests made in JUnit4 to continue to work and comments in build.gradle are added for developers to see which dependencies are for what.