### PR TITLE
Update build.gradle with "release" compiler arg

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,11 @@ plugins {
     id 'jacoco'
 }
 
+compileJava {
+    // Establish compatibility with JDK used to build BlueJ
+    options.compilerArgs.addAll(['--release', '11'])
+}
+
 repositories {
     // Use jcenter for resolving dependencies.
     // You can declare any Maven/Ivy/file repository here.


### PR DESCRIPTION
Added "--release 11" compilerArg to establish compatibility of the extension with the JDK used to build BlueJ.